### PR TITLE
alias_method_chain is deprecated

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,8 @@
+# Stickies 0.1.7
+  alias_method_chain change to alias_method
+  (cause alias_method_chain method is deprecated at rails 5.1 )
+
+  *bunny*
 # Stickies 0.1.6
   defalut close btn removed and update style
 

--- a/lib/stickies/controller_actions.rb
+++ b/lib/stickies/controller_actions.rb
@@ -10,10 +10,10 @@
 # distribute, sublicense, and/or sell copies of the Software, and to
 # permit persons to whom the Software is furnished to do so, subject to
 # the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 # EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 # MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -37,7 +37,7 @@ module Stickies
       end
 
       base.class_eval do
-        alias_method_chain(:call_filter, :stickie_check)
+        alias_method(:call_filter, :stickie_check)
       end
     end
 

--- a/lib/stickies/version.rb
+++ b/lib/stickies/version.rb
@@ -1,4 +1,4 @@
 # -*- encoding : utf-8 -*-
 module Stickies
-  VERSION = "0.1.6"
+  VERSION = '0.1.7'
 end


### PR DESCRIPTION
cause `alias_method_chain` is deprecated on rails 5.1, use `alias_method` instead. 